### PR TITLE
Fixes from first boot on finpilot

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,17 +22,23 @@ FROM ghcr.io/ublue-os/silverblue-main:43
 
 ARG IMAGE_NAME="barbatos"
 ARG IMAGE_VENDOR="gagbo"
+ARG FEDORA_MAJOR_VERSION="43"
 ARG SHA_HEAD_SHORT=""
 ARG SET_X=""
 
 # Brand the OS
 RUN sed -i '/^PRETTY_NAME/s/.*/PRETTY_NAME="Barbatos"/' /usr/lib/os-release
 
-# Build
+# Build — ARGs are forwarded as ENV so build phases can read them
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
+    IMAGE_NAME="${IMAGE_NAME}" \
+    IMAGE_VENDOR="${IMAGE_VENDOR}" \
+    FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}" \
+    SHA_HEAD_SHORT="${SHA_HEAD_SHORT}" \
+    SET_X="${SET_X}" \
     /ctx/build/build.sh
 
 # /opt writeable (needed for k0s, google-chrome, docker-desktop, etc.)

--- a/build/10-copy-oci.sh
+++ b/build/10-copy-oci.sh
@@ -57,9 +57,9 @@ for list in /ctx/custom/flatpaks/*; do
 	install -m 0644 "${list}" "/usr/share/barbatos/flatpaks/$(basename "${list}")"
 done
 
-# ujust auto-discovers .just files in /usr/share/ublue-os/just; dropping our
-# recipe file straight in there is the new finpilot-style integration (no
-# 60-custom.just shim needed).
+# 00-entry.just uses `import? "/usr/share/ublue-os/just/60-custom.just"`, so we
+# ship a 60-custom.just shim that imports our barbatos-*.just recipe files.
+# There is no auto-discovery — the entry point has an explicit import list.
 install -d -m 0755 /usr/share/ublue-os/just
 for recipe in /ctx/custom/ujust/*.just; do
 	install -m 0644 "${recipe}" "/usr/share/ublue-os/just/$(basename "${recipe}")"

--- a/build/50-just-files.sh
+++ b/build/50-just-files.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/bash
 # Phase 50 - Verify that Barbatos ujust recipes landed correctly
 #
-# In the Aurora-based world we appended an `import` line to the legacy
-# 60-custom.just shim. With the new projectbluefin/common layout there is
-# no entry/custom shim - ujust auto-discovers every `.just` file in
-# /usr/share/ublue-os/just. Phase 10 already copied our recipe file there;
-# this phase only sanity-checks the install and runs `just --fmt --check`
-# so a malformed recipe fails the build instead of a running system.
+# The upstream 00-entry.just uses `import?` for 60-custom.just, which in
+# turn imports our barbatos-*.just recipe files. Phase 10 copies all of
+# them into /usr/share/ublue-os/just; this phase sanity-checks the install
+# and runs `just --fmt --check` so a malformed recipe fails the build
+# instead of a running system.
 
 set ${SET_X:+-x} -eou pipefail
 
@@ -30,7 +29,12 @@ if ! ls "${UJUST_DIR}"/barbatos*.just >/dev/null 2>&1; then
 	exit 1
 fi
 
+if [[ ! -f "${UJUST_DIR}/60-custom.just" ]]; then
+	log "ERROR: 60-custom.just shim not found under ${UJUST_DIR}" >&2
+	exit 1
+fi
+
 log "Validating Barbatos recipes with 'just --fmt --check'"
-for recipe in "${UJUST_DIR}"/barbatos*.just; do
+for recipe in "${UJUST_DIR}"/barbatos*.just "${UJUST_DIR}"/60-custom.just; do
 	just --unstable --fmt --check -f "${recipe}"
 done

--- a/build/55-image-info.sh
+++ b/build/55-image-info.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/bash
+# Phase 55 - Generate /usr/share/ublue-os/image-info.json
+#
+# The motd system and several ujust recipes (changelog, toggle-devmode)
+# expect this file. Upstream Bluefin generates it during their build;
+# since Barbatos builds on silverblue-main directly, we must create it.
+
+set ${SET_X:+-x} -eou pipefail
+
+log() {
+	local had_xtrace=0
+	if [[ $- == *x* ]]; then
+		had_xtrace=1
+		set +x
+	fi
+	printf '=== %s ===\n' "$*"
+	if ((had_xtrace)); then set -x; fi
+}
+
+log "Generating image-info.json"
+
+IMAGE_NAME="${IMAGE_NAME:-barbatos}"
+IMAGE_VENDOR="${IMAGE_VENDOR:-gagbo}"
+FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-43}"
+SHA_HEAD_SHORT="${SHA_HEAD_SHORT:-}"
+
+# image-ref follows the OCI reference convention used by bootc
+IMAGE_REF="ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}"
+IMAGE_TAG="stable"
+IMAGE_FLAVOR="main"
+
+install -d -m 0755 /usr/share/ublue-os
+
+cat > /usr/share/ublue-os/image-info.json <<EOF
+{
+  "image-name": "${IMAGE_NAME}",
+  "image-vendor": "${IMAGE_VENDOR}",
+  "image-ref": "${IMAGE_REF}",
+  "image-tag": "${IMAGE_TAG}",
+  "image-flavor": "${IMAGE_FLAVOR}",
+  "fedora-version": "${FEDORA_MAJOR_VERSION}",
+  "sha-head-short": "${SHA_HEAD_SHORT}"
+}
+EOF
+
+log "image-info.json written:"
+cat /usr/share/ublue-os/image-info.json

--- a/build/build.sh
+++ b/build/build.sh
@@ -54,5 +54,6 @@ echo_group /ctx/build/20-repos.sh
 echo_group /ctx/build/30-packages.sh
 echo_group /ctx/build/40-displaylink.sh
 echo_group /ctx/build/50-just-files.sh
+echo_group /ctx/build/55-image-info.sh
 echo_group /ctx/build/60-services.sh
 echo_group /ctx/build/90-cleanup.sh

--- a/custom/ujust/60-custom.just
+++ b/custom/ujust/60-custom.just
@@ -1,0 +1,8 @@
+# vim: set ft=make :
+# 60-custom.just — Barbatos ujust recipe shim
+#
+# The upstream 00-entry.just uses `import?` for this file, so dropping it
+# here is the supported way to wire custom recipes into ujust.
+
+import "/usr/share/ublue-os/just/barbatos-apps.just"
+import "/usr/share/ublue-os/just/barbatos-system.just"

--- a/system_files/usr/share/xdg-desktop-portal/sway-portals.conf
+++ b/system_files/usr/share/xdg-desktop-portal/sway-portals.conf
@@ -1,0 +1,15 @@
+# Shipped by the Barbatos image.
+# Routes xdg-desktop-portal interface requests under a Sway session.
+# xdg-desktop-portal-wlr only implements ScreenCast and Screenshot;
+# everything else falls through to xdg-desktop-portal-gtk, which provides
+# FileChooser, Settings (theme/dconf), Access, Notification, and others.
+# Without this file, the portal daemon auto-detects backends incorrectly
+# and the gtk portal crashes in a loop because it can't open a display.
+[preferred]
+default=gtk
+org.freedesktop.impl.portal.ScreenCast=wlr
+org.freedesktop.impl.portal.Screenshot=wlr
+# gtk's Inhibit calls org.gnome.SessionManager which Sway doesn't provide;
+# routing to none lets apps fall back to Wayland's idle-inhibit protocol.
+# See https://github.com/flatpak/xdg-desktop-portal-gtk/issues/465
+org.freedesktop.impl.portal.Inhibit=none


### PR DESCRIPTION
- Sway needs an explicit desktop-portal config
- Ujust imports were wrong and assumed the incorrect import strategy
- The configuration of sway had the wrong path for `systemd` fix (needs to check in dotfiles and in upstream for what `wait-sni` really means and if it’s still relevant)
