### PR TITLE
Layer Firefox and KeePassXC with en_GB/fr locale support

### DIFF
--- a/build/30-packages.sh
+++ b/build/30-packages.sh
@@ -118,12 +118,18 @@ LAYERED_PACKAGES=(
 	yubikey-manager
 	syncthing syncthing-tools
 	sqlite
+
+	# Browser & password manager
+	firefox
+	firefox-langpacks
+	keepassxc
+
+	# Locale support (en_GB + fr_FR)
+	langpacks-en_GB
+	langpacks-fr
 )
 retry_dnf 5 dnf5 install --refresh --setopt=install_weak_deps=False -y \
 	"${LAYERED_PACKAGES[@]}"
-
-# Remove Host firefox, we install and use a flatpak
-dnf5 remove firefox -y
 
 log "Disabling Copr repos that we only needed at build time"
 if [[ -f /tmp/barbatos/copr-repos ]]; then

--- a/custom/flatpaks/generic
+++ b/custom/flatpaks/generic
@@ -16,7 +16,6 @@ org.kde.kate
 org.kde.kdenlive
 org.kde.krita
 org.libreoffice.LibreOffice
-org.mozilla.firefox
 org.mozilla.Thunderbird
 org.openstreetmap.josm
 org.pulseaudio.pavucontrol


### PR DESCRIPTION
## Summary

- Layer Firefox, KeePassXC, and locale support (en_GB + fr) directly into the image as RPMs
- Remove Firefox Flatpak from the generic flatpak list (existing Flatpak installs are unaffected — migrate profile at your own pace)

## Changes

- **`build/30-packages.sh`**: Add `firefox`, `firefox-langpacks`, `keepassxc`, `langpacks-en_GB`, `langpacks-fr` to layered packages. Remove the `dnf5 remove firefox -y` that was stripping Firefox from the image.
- **`custom/flatpaks/generic`**: Remove `org.mozilla.firefox` entry.

## Codec strategy

No extra codec packages added. The `silverblue-main:44` base already ships full `libavcodec`/`ffmpeg-libs` from `fedora-multimedia` (H.264, AAC, VP9, etc.), so Firefox uses them natively. This avoids the `ffmpeg-free` vs `fedora-multimedia` conflict seen in #64.

## Migration note

Flatpak Firefox profile lives in `~/.var/app/org.mozilla.firefox/.mozilla/firefox/`. To migrate to system Firefox:

```bash
cp -rf ~/.var/app/org.mozilla.firefox/.mozilla/firefox/* ~/.mozilla/firefox/
flatpak uninstall org.mozilla.firefox
```