### PR TITLE
Remove duplicate auto-update alias

### DIFF
--- a/custom/ujust/barbatos-update.just
+++ b/custom/ujust/barbatos-update.just
@@ -36,8 +36,6 @@ update:
         /var/home/linuxbrew/.linuxbrew/bin/brew upgrade
     fi
 
-alias auto-update := toggle-updates
-
 # Turn automatic updates on or off
 [group('System')]
 toggle-updates ACTION="prompt":


### PR DESCRIPTION
## Summary
- Remove `alias auto-update := toggle-updates` from `barbatos-update.just` since upstream `update.just` now defines it, causing a runtime redefinition error.

Same pattern as #64 which removed the duplicate `upgrade` alias.